### PR TITLE
CSVExporter now can export x- and y-axis errors

### DIFF
--- a/git-push
+++ b/git-push
@@ -1,0 +1,2 @@
+COMMIT=$1
+git add . && git commit -m "$COMMIT" && git remote -v && git push origin exostriker_branch

--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -3,22 +3,20 @@ from ..Qt import QtGui, QtCore
 from .Exporter import Exporter
 from ..parametertree import Parameter
 from .. import PlotItem
-from ..python2_3 import asUnicode
-
-translate = QtCore.QCoreApplication.translate
+from ..python2_3 import asUnicode 
 
 __all__ = ['CSVExporter']
     
     
 class CSVExporter(Exporter):
     Name = "CSV from plot data"
-    windows = []
+    windows = [] 
     def __init__(self, item):
         Exporter.__init__(self, item)
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'separator', 'title': translate("Exporter", 'separator'), 'type': 'list', 'value': 'comma', 'values': ['comma', 'tab']},
-            {'name': 'precision', 'title': translate("Exporter", 'precision'), 'type': 'int', 'value': 10, 'limits': [0, None]},
-            {'name': 'columnMode', 'title': translate("Exporter", 'columnMode'), 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']}
+            {'name': 'separator', 'type': 'list', 'value': 'comma', 'values': ['comma', 'tab']},
+            {'name': 'precision', 'type': 'int', 'value': 10, 'limits': [0, None]},
+            {'name': 'columnMode', 'type': 'list', 'values': ['(x,y,err_y,err_x) per plot ', '(x,y,y,y) for all plots']}
         ])
         
     def parameters(self):
@@ -36,23 +34,52 @@ class CSVExporter(Exporter):
         data = []
         header = []
 
-        appendAllX = self.params['columnMode'] == '(x,y) per plot'
+
+        appendAllX = self.params['columnMode'] == '(x,y,err_y,err_x) per plot'
 
         for i, c in enumerate(self.item.curves):
             cd = c.getData()
             if cd[0] is None:
                 continue
             data.append(cd)
+
+            #print(cd)
+
+
             if hasattr(c, 'implements') and c.implements('plotData') and c.name() is not None:
                 name = c.name().replace('"', '""') + '_'
                 xName, yName = '"'+name+'x"', '"'+name+'y"'
             else:
                 xName = 'x%04d' % i
                 yName = 'y%04d' % i
+                e_yName = 'e_y%04d' % i
+                e_xName = 'e_x%04d' % i
+
             if appendAllX or i == 0:
-                header.extend([xName, yName])
+                header.extend([xName, yName,e_yName,e_xName ])
             else:
-                header.extend([yName])
+                header.extend([yName,e_yName,e_xName ])
+
+        for indx, item in enumerate(self.item.items):
+
+            if self.item.items[indx].__class__.__name__ == "InfiniteLine":                   
+                continue   
+            if self.item.items[indx].__class__.__name__ == "FillBetweenItem":                               
+                continue
+            if self.item.items[indx].__class__.__name__ == "TextItem":
+                continue
+
+            if "top" in self.item.items[indx].opts:
+                yerr=self.item.items[indx].opts["top"]
+                data[1] = list(data[1])
+                data[1].append(yerr)
+                data[1] = tuple(data[1])
+
+            if "left" in self.item.items[indx].opts:
+                xerr=self.item.items[indx].opts["left"]
+                data[1] = list(data[1])
+                data[1].append(xerr)
+                data[1] = tuple(data[1])
 
         if self.params['separator'] == 'comma':
             sep = ','
@@ -79,7 +106,22 @@ class CSVExporter(Exporter):
                         fd.write(numFormat % d[1][i] + sep)
                     else:
                         fd.write(' %s' % sep)
+
+                    # write data e_y value
+                    if d is not None and len(d)>2 and d[2] is not None and i < len(d[2]):
+                            fd.write(numFormat % d[2][i] + sep)
+                    else:
+                        fd.write(' %s' % sep)
+
+                    # write data e_x value
+                    if d is not None and len(d)>3 and d[3] is not None and i < len(d[3]):
+                            fd.write(numFormat % d[3][i] + sep)
+                    else:
+                        fd.write(' %s' % sep)
+
                 fd.write('\n')
 
 
 CSVExporter.register()        
+                
+        


### PR DESCRIPTION
This is connected to https://github.com/pyqtgraph/pyqtgraph/issues/1365 

CSVExporter now can export x- and y-axis errors, if such are introduced by the ErrorBarItem. This is my fix, and it works well for the Exo-Striker tool. Yet, a more elegant code solution could exist.